### PR TITLE
Use https:// for the base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ disqus_shortname: springerpe
 # Your site's domain goes here. When working locally use localhost server leave blank
 # PS. If you set this wrong stylesheets and scripts won't load and most links will break.
 # PPS. If you leave it blank for local testing home links won't work, they'll be fine for live domains though.
-url:              http://springerpe.github.io
+url:              https://springerpe.github.io
 # production_url:              http://springerpe.github.io      
 # author information
 author_ids: [otte, keymon, simon, katter, jose, marc, josef, jorja, ryan, felix]


### PR DESCRIPTION
Github now uses https:// as default for the jekyll pages. Because that, the static assets referred from this page fail loading because the browser complains of "mixed content".

Setting this url to https, should fix the problem.
